### PR TITLE
Use the help option in the CLI

### DIFF
--- a/content/docs/get-started/quick-start.md
+++ b/content/docs/get-started/quick-start.md
@@ -38,7 +38,7 @@ cargo install rulex-bin
 To find out how to use the CLI, run
 
 ```
-rulex help
+rulex --help
 ```
 
 ## Rust macro


### PR DESCRIPTION
`rulex help` doesn't display the help and instead tries to parse `help` as a Rulex expression

I was getting this error when running `rulex help`:
```
Error: 
  × Variable doesn't exist
   ╭────
 1 │ help
   · ──┬─
   ·   ╰── error occurred here
   ╰────
   ```